### PR TITLE
Cleanup.

### DIFF
--- a/etc/udev/rules.d/90-backlight.rules
+++ b/etc/udev/rules.d/90-backlight.rules
@@ -1,4 +1,4 @@
-#Rules to allow controlling of backlight and leds for video group
+#Rules to allow controlling of backlight and leds for video and input groups
 ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chgrp video /sys/class/backlight/%k/brightness"
 ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"
 ACTION=="add", SUBSYSTEM=="leds", RUN+="/bin/chgrp input /sys/class/leds/%k/brightness"

--- a/usr/bin/droid/droid-get-bt-address.sh
+++ b/usr/bin/droid/droid-get-bt-address.sh
@@ -5,4 +5,3 @@ find /var/lib/bluetooth -maxdepth 1 -iname '*:*:*:*:*:*' | cut -d/ -f 5 > /var/l
 chown root:root /var/lib/bluetooth/board-address
 chmod 644 /var/lib/bluetooth/board-address
 
-rfkill unblock bluetooth


### PR DESCRIPTION
Fixed typo in 90-backlight.rules filename and made the comment inside more accurate.
Removed unnecessary rfkill command from droid-get-bt-address.sh as Bluetooth works perfectly fine without it.