### PR TITLE
Added udev rules to fix cursor showing up when bluetooth device connected issue

### DIFF
--- a/etc/udev/rules.d/90-btdevice-cursorfix.rules
+++ b/etc/udev/rules.d/90-btdevice-cursorfix.rules
@@ -1,0 +1,3 @@
+# Rules to fix cursor showing up on a Bluetooth device connection
+
+ACTION=="add", KERNEL=="event8", SUBSYSTEM=="input", ENV{LIBINPUT_IGNORE_DEVICE}="1"


### PR DESCRIPTION
Added new udev rules file `90-btdevice-cursorfix.rules` to solve Cursor showing up when bluetooth device is connected issue !! 